### PR TITLE
e2e: add basic e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,17 @@ jobs:
   container:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build container
+      uses: docker/build-push-action@v5
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
@@ -25,14 +35,60 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
+        load: true
+        tags: quay.io/observatorium/namespace-provisioner:test
+    - name: Setup Kubernetes
+      uses: helm/kind-action@v1.8.0
+      with:
+        cluster_name: e2e
+    - name: Install namespace-provisioner
+      run: |
+        SERVER="$(kubectl config view -o jsonpath='{.clusters[?(@.name == "kind-e2e")].cluster.server}')"
+        kind load docker-image --name e2e quay.io/observatorium/namespace-provisioner:test
+        kubectl apply -f manifests/namespace-provisioner.yaml
+        cat <<EOF | kubectl apply -f -
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: namespace-provisioner
+          namespace: namespace-provisioner
+        data:
+          server: "$SERVER"
+        EOF
+        cat <<EOF | kubectl apply -f -
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: namespace-provisioner-grant
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - list
+        EOF
+        kubectl -n namespace-provisioner set image deployment namespace-provisioner namespace-provisioner=quay.io/observatorium/namespace-provisioner:test
+        kubectl -n namespace-provisioner rollout status deployment namespace-provisioner --timeout 1m
+    - name: Test namespace-provisioner
+      run: |
+        kubectl -n namespace-provisioner port-forward service/namespace-provisioner 8080 &
+        until lsof -nP -iTCP:8080 -sTCP:LISTEN >/dev/null; do sleep 1; done
+        curl localhost:8080/api/v1/namespace -X POST -H "Authorization: bearer PASSWORD" > kubeconfig
+        kubectl --kubeconfig kubeconfig get pods
+    - name: Debug failure
+      if: failure()
+      run: |
+        kubectl get -A all
+        kubectl -n namespace-provisioner logs deploy/namespace-provisioner
 
   push:
     if: github.event_name != 'pull_request'
     needs:
     - container
+    - e2e
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
@@ -50,7 +106,6 @@ jobs:
       id: push
       uses: docker/build-push-action@v5
       with:
-        context: .
         push: true
         platforms: linux/arm64, linux/amd64
         tags: quay.io/observatorium/namespace-provisioner:latest, quay.io/observatorium/namespace-provisioner:${{ steps.sha.outputs.sha }}

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func Main() error {
 	listen := flag.String("listen", ":8080", "The address at which to to serve the API.")
 	listenInternal := flag.String("listen-internal", ":9090", "The address at which to to serve the internal API.")
 	logLevel := flag.String("log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", availableLogLevels))
-	apiServer := flag.String("server", "kubernetes", "The address of the Kubernetes API server to use in generated kubeconfigs.")
+	apiServer := flag.String("server", "https://kubernetes", "The address of the Kubernetes API server to use in generated kubeconfigs.")
 	clusterRole := flag.String("cluster-role", "", "The of a Kubernetes ClusterRole to bind to ServiceAccounts in created Namespaces.")
 	prefix := flag.String("prefix", "np", "The prefix to use for Namespace names.")
 	selector := flag.String("selector", "controller.observatorium.io=namespace-selector", "The label selector to use to select resources.")

--- a/manifests/namespace-provisioner.yaml
+++ b/manifests/namespace-provisioner.yaml
@@ -18,6 +18,17 @@ stringData:
   token: PASSWORD
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: namespace-provisioner
+  namespace: namespace-provisioner
+  labels:
+    app.kubernetes.io/name: namespace-provisioner
+    app.kubernetes.io/part-of: namespace-provisioner
+data:
+  server: https://kubernetes
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: namespace-provisioner
@@ -94,6 +105,22 @@ subjects:
     namespace: namespace-provisioner
     name: namespace-provisioner
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: namespace-provisioner
+  namespace: namespace-provisioner
+  labels:
+    app.kubernetes.io/name: namespace-provisioner
+    app.kubernetes.io/part-of: namespace-provisioner
+spec:
+  selector:
+    app.kubernetes.io/name: namespace-provisioner
+    app.kubernetes.io/part-of: namespace-provisioner
+  ports:
+  - port: 8080
+    targetPort: http
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -126,6 +153,7 @@ spec:
         - --listen=:8080
         - --listen-internal=:9090
         - --cluster-role=namespace-provisioner-grant
+        - --server=$(SERVER)
         - --token=$(TOKEN)
         env:
         - name: TOKEN
@@ -133,6 +161,11 @@ spec:
             secretKeyRef:
               name: namespace-provisioner
               key: token
+        - name: SERVER
+          valueFrom:
+            configMapKeyRef:
+              name: namespace-provisioner
+              key: server
         ports:
         - containerPort: 8080
           name: http


### PR DESCRIPTION
This commit adds a simple e2e test to the repository.
The test:
1. spins up a kind cluster
2. deploys the namespace-provisioner
3. exposes the namespace-provisioner API using `kubectl port-forward`
4. creates a namespace over the API using cURL
5. exercises the returned kubeconfig to verify that the granted role
   works.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
