### PR TITLE
fix: use durations for TTL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           namespace: namespace-provisioner
         data:
           server: "$SERVER"
+          ttl: 1h
         EOF
         kubectl apply -f manifests/example-grants/pods.yaml
         kubectl -n namespace-provisioner set image deployment namespace-provisioner namespace-provisioner=quay.io/observatorium/namespace-provisioner:test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
         kubectl -n namespace-provisioner port-forward service/namespace-provisioner 8080 &
         until lsof -nP -iTCP:8080 -sTCP:LISTEN >/dev/null; do sleep 1; done
-        curl localhost:8080/api/v1/namespace?ttl=1 -X POST -H "Authorization: bearer PASSWORD" > kubeconfig
+        curl localhost:8080/api/v1/namespace?ttl=1s -X POST -H "Authorization: bearer PASSWORD" > kubeconfig
         kubectl --kubeconfig kubeconfig get pods
         sleep 5
         [ $(kubectl get ns | grep np- | wc -l) -eq 0 ]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Namespace Provisioner runs an API server over HTTP that exposes two API endp
 #### Namespace Creation - POST /api/v1/namespace
 
 The Namespace creation endpoint accepts the following optional query parameters:
-1. `ttl`: the time in seconds that the Namespace should exist in the Kubernetes cluster; if 0 is given, then the Namespace Provisioner’s default lifetime is applied.
+1. `ttl`: the duration, e.g. `30s`, `5m`, `1h`, that the Namespace should exist in the Kubernetes cluster; if 0 is given, then the Namespace Provisioner’s default lifetime is applied.
 All provisioned Namespaces will be labeled with a Unix timestamp equal to the current time plus this duration; and
 1. `url`; the URL of the Kubernetes API that the generated Kubeconfig should use.
 

--- a/manifests/namespace-provisioner.yaml
+++ b/manifests/namespace-provisioner.yaml
@@ -36,6 +36,7 @@ metadata:
     app.kubernetes.io/part-of: namespace-provisioner
 data:
   server: https://kubernetes
+  ttl: 1h
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -163,6 +164,7 @@ spec:
         - --listen-internal=:9090
         - --cluster-role=namespace-provisioner-grant
         - --server=$(SERVER)
+        - --ttl=$(TTL)
         - --token=$(TOKEN)
         env:
         - name: TOKEN
@@ -175,6 +177,11 @@ spec:
             configMapKeyRef:
               name: namespace-provisioner
               key: server
+        - name: TTL
+          valueFrom:
+            configMapKeyRef:
+              name: namespace-provisioner
+              key: ttl
         ports:
         - containerPort: 8080
           name: http


### PR DESCRIPTION
Previously, we defined the TTL as a duration on the CLI but as an
integer corresponding to seconds in the HTTP API. Let's standardize on
one format: duration.

Signed-off-by: squat <lserven@gmail.com>
